### PR TITLE
Добавил .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,8 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[Makefile]
+indent_style = tab
+
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
[EditorConfig](http://editorconfig.org) устанавливает настройки редактора, такие как идентация, для различных редакторов.
Благодаря этому не нужно перенастравить редактор для каждого проекта.

[Плагины для редакторов](http://editorconfig.org/#download)
